### PR TITLE
Resolved forward reference in RedisCluster

### DIFF
--- a/src/main/scala/redis/RedisCluster.scala
+++ b/src/main/scala/redis/RedisCluster.scala
@@ -25,6 +25,9 @@ case class RedisCluster(redisServers: Seq[RedisServer],
 
   val log = Logging.getLogger(_system, this)
 
+  val clusterSlotsRef:Ref[Option[Map[ClusterSlot, RedisConnection]]] = Ref(Option.empty[Map[ClusterSlot, RedisConnection]])
+  val lockClusterSlots = Ref(true)
+
   override val redisServerConnections = {
     redisServers.map { server =>
       makeRedisConnection(server, defaultActive = true)
@@ -52,10 +55,6 @@ case class RedisCluster(redisServers: Seq[RedisServer],
 
     }
   }
-
-  val clusterSlotsRef:Ref[Option[Map[ClusterSlot, RedisConnection]]] = Ref(Option.empty[Map[ClusterSlot, RedisConnection]])
-  val lockClusterSlots = Ref(true)
-  Await.result(asyncRefreshClusterSlots(force=true), Duration(10,TimeUnit.SECONDS))
 
   def getClusterSlots(): Future[Map[ClusterSlot, RedisConnection]] = {
 
@@ -185,6 +184,7 @@ case class RedisCluster(redisServers: Seq[RedisServer],
     }.values.toSeq
   }
 
+  Await.result(asyncRefreshClusterSlots(force=true), Duration(10,TimeUnit.SECONDS))
 }
 
 


### PR DESCRIPTION
This PR fixes https://github.com/etaty/rediscala/issues/160

There was a very ugly forward reference, which could possibly occur under a certain (race) conditions.

Error callstack:

1. [init of val in `redisServerConnections`](https://github.com/etaty/rediscala/blob/master/src/main/scala/redis/RedisCluster.scala#L27)
1. `makeRedisConnection`
1. `makeRedisClientActor` (in `RedisClientPoolLike`)

this creates a new actor and passes in the `onConnectStatus` function, which uses possibly uninitialized `clusterSlotsRef`. Under the certain race conditions, the `onConnectStatus` could be called before the initialization of the val `clusterSlotsRef` happened.