### PR TITLE
Complete operations with a failure if deserializing response fails

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,11 +56,8 @@ lazy val root = (project in file(".")).settings(
   name := "rediscala",
   logBuffered in Test := true,
   libraryDependencies ++= Seq(
-    "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0" % "test->test"
-  ),
-  dependencyOverrides ++= Seq(
-    // log4j-api-scala brings in 3.2.0-M1
-    "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+    // log4j-api-scala brings in scalatest 3.2.0-M1
+    "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0" % "test->test" exclude("org.scalatest", "*")
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-lazy val log4jScala = RootProject(uri("git://github.com/vimalaguti/logging-log4j-scala/#b340a2b930b60e90c743ce30438d34fb2486560e"))
-
 lazy val common = Seq(
   organization := "com.github.Ma27",
   publishTo := sonatypePublishTo.value,
@@ -19,7 +17,9 @@ lazy val common = Seq(
     </developers>,
   resolvers ++= Seq(
     "Typesafe repository snapshots" at "https://repo.typesafe.com/typesafe/snapshots/",
-    "Typesafe repository releases" at "https://repo.typesafe.com/typesafe/releases/"
+    "Typesafe repository releases" at "https://repo.typesafe.com/typesafe/releases/",
+    // using staging artifact until 2.13 release is ready: https://github.com/apache/logging-log4j-scala/pull/3
+    "Apache staging repository" at "https://repository.apache.org/content/repositories/staging"
   ),
   publishMavenStyle := true,
   scalacOptions ++= Seq(
@@ -54,8 +54,15 @@ lazy val common = Seq(
 lazy val root = (project in file(".")).settings(
   common,
   name := "rediscala",
-  logBuffered in Test := true
-).dependsOn(log4jScala % "test->test")
+  logBuffered in Test := true,
+  libraryDependencies ++= Seq(
+    "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0" % "test->test"
+  ),
+  dependencyOverrides ++= Seq(
+    // log4j-api-scala brings in 3.2.0-M1
+    "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+  )
+)
 
 lazy val bench = (project in file("src/bench"))
   .settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 
 resolvers += Resolver.url(
   "bintray-sbt-plugin-releases",
-  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
+  url("https://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
     Resolver.ivyStylePatterns)
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")

--- a/src/main/scala/redis/Operation.scala
+++ b/src/main/scala/redis/Operation.scala
@@ -4,6 +4,8 @@ import scala.concurrent.Promise
 import redis.protocol.{DecodeResult, RedisReply}
 import akka.util.ByteString
 
+import scala.util.Try
+
 case class Operation[RedisReplyT <: RedisReply, T](redisCommand: RedisCommand[RedisReplyT, T], promise: Promise[T]) {
   def decodeRedisReplyThenComplete(bs: ByteString): DecodeResult[Unit] = {
     val r = redisCommand.decodeRedisReply.apply(bs)
@@ -13,13 +15,13 @@ case class Operation[RedisReplyT <: RedisReply, T](redisCommand: RedisCommand[Re
   }
 
   def completeSuccess(redisReply: RedisReplyT): Promise[T] = {
-    val v = redisCommand.decodeReply(redisReply)
-    promise.success(v)
+    val v = Try(redisCommand.decodeReply(redisReply))
+    promise.complete(v)
   }
 
   def tryCompleteSuccess(redisReply: RedisReply) = {
-    val v = redisCommand.decodeReply(redisReply.asInstanceOf[RedisReplyT])
-    promise.trySuccess(v)
+    val v = Try(redisCommand.decodeReply(redisReply.asInstanceOf[RedisReplyT]))
+    promise.tryComplete(v)
   }
 
   def completeSuccessValue(value: T) = promise.success(value)

--- a/src/test/scala/redis/issues/Issue26Spec.scala
+++ b/src/test/scala/redis/issues/Issue26Spec.scala
@@ -1,6 +1,7 @@
 package redis.issues
 
 import org.scalatest.RecoverMethods._
+import org.scalatest.Succeeded
 import redis._
 
 class Issue26Spec extends RedisStandaloneServer {
@@ -8,7 +9,7 @@ class Issue26Spec extends RedisStandaloneServer {
   "Deserializer exceptions" should {
     "be propagated to resulting future" in {
       redis.set("key", "value").futureValue shouldBe true
-      recoverToSucceededIf[NumberFormatException](redis.get[Double]("key")).futureValue
+      recoverToSucceededIf[NumberFormatException](redis.get[Double]("key")).futureValue shouldBe Succeeded
     }
   }
 }

--- a/src/test/scala/redis/issues/Issue26Spec.scala
+++ b/src/test/scala/redis/issues/Issue26Spec.scala
@@ -1,0 +1,13 @@
+package redis.issues
+
+import redis._
+
+class Issue26Spec extends RedisStandaloneServer {
+
+  "Deserializer exceptions" should {
+    "be propagated to resulting future" in {
+      redis.set("key", "value").futureValue shouldBe true
+      assertThrows[NumberFormatException](redis.get[Double]("key").futureValue)
+    }
+  }
+}

--- a/src/test/scala/redis/issues/Issue26Spec.scala
+++ b/src/test/scala/redis/issues/Issue26Spec.scala
@@ -1,5 +1,6 @@
 package redis.issues
 
+import org.scalatest.RecoverMethods._
 import redis._
 
 class Issue26Spec extends RedisStandaloneServer {
@@ -7,7 +8,7 @@ class Issue26Spec extends RedisStandaloneServer {
   "Deserializer exceptions" should {
     "be propagated to resulting future" in {
       redis.set("key", "value").futureValue shouldBe true
-      assertThrows[NumberFormatException](redis.get[Double]("key").futureValue)
+      recoverToSucceededIf[NumberFormatException](redis.get[Double]("key")).futureValue
     }
   }
 }


### PR DESCRIPTION
Fixes #26 

Requests would previously never complete if an exception was thrown by the deserializer